### PR TITLE
Bossmonster level test

### DIFF
--- a/game/src/ecs/entities/Shopkeeper.java
+++ b/game/src/ecs/entities/Shopkeeper.java
@@ -183,7 +183,7 @@ public class Shopkeeper extends Entity {
         }
         else if(text.toLowerCase().contains("sell this item")) {
             return buyItem(icFromHero,hero);
-        } else if ( text.toLowerCase().contains("Special")) {
+        } else if ( text.toLowerCase().contains("special")) {
             Game.bossRoom = true;
             return "If you go down the next ladder, you will fight against the Boss";
         } else if (text.matches("[0-9]+")) {

--- a/game/src/ecs/entities/Shopkeeper.java
+++ b/game/src/ecs/entities/Shopkeeper.java
@@ -20,7 +20,7 @@ public class Shopkeeper extends Entity {
 
     private ItemData[] possibleItemsInShop = new ItemData[]{new Telestone().getItemData(), new Damagestone().getItemData(),
         new PotionOfHealing().getItemData()};
-    public static int moduloForLevelSpawn = 15;
+    public static int moduloForLevelSpawn = 1;
     private boolean haggle;
     private int dice;
     private float currentPriceFactor;
@@ -183,8 +183,10 @@ public class Shopkeeper extends Entity {
         }
         else if(text.toLowerCase().contains("sell this item")) {
             return buyItem(icFromHero,hero);
-        }
-        else if (text.matches("[0-9]+")) {
+        } else if ( text.toLowerCase().contains("Special")) {
+            Game.bossRoom = true;
+            return "If you go down the next ladder, you will fight against the Boss";
+        } else if (text.matches("[0-9]+")) {
             return "I don't know, what to do with\n all this numbers, sorry!";
         } else if (text.matches("[A-Za-z ]+")) {
             return "I don't understand these words!";

--- a/game/src/level/elements/TileLevel.java
+++ b/game/src/level/elements/TileLevel.java
@@ -45,6 +45,18 @@ public class TileLevel implements ILevel {
     }
 
     /**
+     * Create a new level without an end tile
+     *
+     * @param layout The layout of the level.
+     */
+    public TileLevel(Tile[][] layout, String name) {
+        this.layout = layout;
+        putTilesInLists();
+        if (startTile == null) startTile = layout[16][16];
+    }
+
+
+    /**
      * Create a new Level
      *
      * @param layout The layout of the Level

--- a/game/src/starter/Game.java
+++ b/game/src/starter/Game.java
@@ -30,11 +30,16 @@ import java.util.logging.Logger;
 import level.IOnLevelLoader;
 import level.LevelAPI;
 import level.elements.ILevel;
+import level.elements.TileLevel;
 import level.elements.tile.Tile;
+import level.elements.tile.TileFactory;
 import level.generator.IGenerator;
 import level.generator.postGeneration.WallGenerator;
 import level.generator.randomwalk.RandomWalkGenerator;
 import level.monstergenerator.EntitySpawnRateSetter;
+import level.tools.Coordinate;
+import level.tools.DesignLabel;
+import level.tools.LevelElement;
 import level.tools.LevelSize;
 import tools.Constants;
 import tools.Point;
@@ -43,6 +48,10 @@ import tools.Point;
  * The heart of the framework. From here all strings are pulled.
  */
 public class Game extends ScreenAdapter implements IOnLevelLoader {
+
+    /** boolean to check if the next ladder gets you to the boss*/
+    public static boolean bossRoom = false;
+
 
     private final LevelSize LEVELSIZE = LevelSize.SMALL;
 
@@ -233,7 +242,9 @@ public class Game extends ScreenAdapter implements IOnLevelLoader {
     }
 
     private void loadNextLevelIfEntityIsOnEndTile(Entity hero) {
-        if (isOnEndTile(hero)) levelAPI.loadLevel(LEVELSIZE);
+        if (isOnEndTile(hero) && bossRoom == false) levelAPI.loadLevel(LEVELSIZE);
+        else if ( isOnEndTile(hero) && bossRoom == true) startBossMonsterLevel();
+
     }
 
     private boolean isOnEndTile(Entity entity) {
@@ -483,5 +494,46 @@ public class Game extends ScreenAdapter implements IOnLevelLoader {
                 inv.removeItem(items.get(i));
         }
         placeOnLevelStart(hero);
+    }
+
+    public void startBossMonsterLevel() {
+        Tile[][] tiles = createTilesTest();
+        ILevel levelforBoss = new TileLevel(tiles,"BossMonsterLevel");
+        levelAPI.setLevel(levelforBoss);
+        System.out.println("test in game 516 " + tiles[0][0].getCoordinate().x + " : " + tiles[0][0].getCoordinate().y + " ; " + tiles[20][15].getCoordinate().x +  " : "  + tiles[20][15].getCoordinate().y );
+    }
+
+    private Tile[][] createTilesTest() {
+        Tile[][] tiles = new Tile[32][32];
+        for ( int i = 0; i < 32; i++) {
+            for ( int j = 0; j < 32; j++) {
+                tiles[i][j] = TileFactory.createTile("dungeon/default/floor/empty.png", new Coordinate(i,j), LevelElement.SKIP, null);
+            }
+        }
+        for ( int i = 8; i < 24;i++) {
+            for ( int j = 8; j < 24; j++) {
+                if (i == 8 && j == 8) {
+                    tiles[i][j] = TileFactory.createTile("dungeon/default/wall/wall_outer_corner_upper_left.png", new Coordinate(i, j), LevelElement.WALL, null);
+                } else if (i == 8 && j == 23) {
+                    tiles[i][j] = TileFactory.createTile("dungeon/default/wall/wall_outer_corner_upper_right.png", new Coordinate(i, j), LevelElement.WALL, DesignLabel.randomDesign());
+                } else if (i == 23 && j == 8) {
+                    tiles[i][j] = TileFactory.createTile("dungeon/default/wall/wall_outer_corner_bottom_left.png", new Coordinate(i, j), LevelElement.WALL, DesignLabel.randomDesign());
+                } else if (i == 23 && j == 23) {
+                    tiles[i][j] = TileFactory.createTile("dungeon/default/wall/wall_outer_corner_bottom_right.png", new Coordinate(i, j), LevelElement.WALL, DesignLabel.randomDesign());
+                } else if (i == 8 && j > 8 && j < 23) {
+                    tiles[i][j] = TileFactory.createTile("dungeon/default/wall/wall_top.png", new Coordinate(i, j), LevelElement.WALL, DesignLabel.randomDesign());
+                } else if (i > 8 && i < 23 && j == 8) {
+                    tiles[i][j] = TileFactory.createTile("dungeon/default/wall/wall_left.png", new Coordinate(i, j), LevelElement.WALL, DesignLabel.randomDesign());
+                } else if (i == 23 && j > 8 && j < 23) {
+                    tiles[i][j] = TileFactory.createTile("dungeon/default/wall/wall_right.png", new Coordinate(i, j), LevelElement.WALL, DesignLabel.randomDesign());
+                } else if (i > 8 && i < 23 && j == 23) {
+                    tiles[i][j] = TileFactory.createTile("dungeon/default/wall/wall_bottom.png", new Coordinate(i, j), LevelElement.WALL, DesignLabel.randomDesign());
+                } else {
+                    tiles[i][j] = TileFactory.createTile("dungeon/default/floor/floor_1.png", new Coordinate(i, j), LevelElement.FLOOR, DesignLabel.randomDesign());
+                }
+            }
+        }
+
+        return tiles;
     }
 }


### PR DESCRIPTION
Das Bossmonsterlevel wird aufgerufen, indem man dem Shopkeeper das Wort special mitgibt.
Wenn man nun auf die nächste Leiter geht, spawnt man in einem 32x32 Level, wo eine 16x16 "spielbare" Fläche ist.
Wir erstellen momentan das neue Level über ein zweidimensionales Array an Tiles, bzw. Floortiles und walltiles, Klasse Game.java.
Dazu haben wir einen neuen Konstruktor in Tilelevel, welche nur das Layout und einen Namem bekommt, um den alten Konstruktor zu überladen. Dieser Konstruktor arbeitet wie der vorherige, nur lässt dieser das Endtile aus und erzeugt keine Leiter.
nachdem das zweidimensionale Array gefüllt wurde und zu einem Tilelevel gemacht wurde, setzen wir mit 
levelAPI.setLevel() das neue Level ein.
